### PR TITLE
Add space to the end of filter conditions in the query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,13 @@
+# Changelog
+
+## 1.3.0
+Recursively load the JSON response to remove improper characters
+
+## 1.2.0
+Add support for filtering by timespan instead of start and end date
+
+## 1.1.0
+Adds support for multiple repeat filters
+
+## 1.0.0
+First version released

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## Unreleased
+Fix bug when only the first of the filter conditions (eg. keyword, near, etc.) was used
+
 ## 1.3.0
 Recursively load the JSON response to remove improper characters
 

--- a/gdeltdoc/filters.py
+++ b/gdeltdoc/filters.py
@@ -14,7 +14,7 @@ def near(n: int, *args) -> str:
     if len(args) < 2:
         raise ValueError("At least two words must be provided")
 
-    return f"near{str(n)}:" + '"' + " ".join([a for a in args]) + '"'
+    return f"near{str(n)}:" + '"' + " ".join([a for a in args]) + '" '
 
 
 def repeat(n: int, keyword: str) -> str:
@@ -29,7 +29,7 @@ def repeat(n: int, keyword: str) -> str:
     if " " in keyword:
         raise ValueError("Only single words can be repeated")
 
-    return f'repeat{str(n)}:"{keyword}"'
+    return f'repeat{str(n)}:"{keyword}" '
 
 
 def multi_repeat(repeats: List[Tuple[int, str]], method: str) -> str:
@@ -190,11 +190,11 @@ class Filters:
             The converted filter. Eg. "domain:cnn.com"
         """
         if type(f) == str:
-            return f"{name}:{f}"
+            return f"{name}:{f} "
 
         else:
             # Build an OR statement
-            return "(" + " OR ".join([f"{name}:{clause}" for clause in f]) + ")"
+            return "(" + " OR ".join([f"{name}:{clause}" for clause in f]) + ") "
 
     @staticmethod
     def _keyword_to_string(keywords: Filter) -> str:
@@ -215,7 +215,7 @@ class Filters:
             The converted filter eg. "(airline OR shipping)"
         """
         if type(keywords) == str:
-            return f'"{keywords}"'
+            return f'"{keywords}" '
 
         else:
             return (
@@ -223,5 +223,5 @@ class Filters:
                 + " OR ".join(
                     [f'"{word}"' if " " in word else word for word in keywords]
                 )
-                + ")"
+                + ") "
             )

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -11,29 +11,29 @@ class FiltersTestCase(unittest.TestCase):
     def test_single_keyword_filter(self):
         f = Filters(keyword="airline", start_date="2020-03-01", end_date="2020-03-02")
         self.assertEqual(f.query_string,
-                         '"airline"&startdatetime=20200301000000&enddatetime=20200302000000&maxrecords=250')
+                         '"airline" &startdatetime=20200301000000&enddatetime=20200302000000&maxrecords=250')
 
     def test_single_keyphrase_filter(self):
         f = Filters(keyword="climate change", start_date="2020-03-01", end_date="2020-03-02")
         self.assertEqual(f.query_string,
-                         '"climate change"&startdatetime=20200301000000&enddatetime=20200302000000&maxrecords=250')
+                         '"climate change" &startdatetime=20200301000000&enddatetime=20200302000000&maxrecords=250')
 
     def test_multiple_keywords(self):
         f = Filters(keyword=["airline", "climate"], start_date = "2020-05-13", end_date = "2020-05-14")
         self.assertEqual(f.query_string,
-                         '(airline OR climate)&startdatetime=20200513000000&'
+                         '(airline OR climate) &startdatetime=20200513000000&'
                          'enddatetime=20200514000000&maxrecords=250')
 
     def test_multiple_themes(self):
         f = Filters(theme=["ENV_CLIMATECHANGE", "LEADER"], start_date="2020-05-13", end_date="2020-05-14")
         self.assertEqual(f.query_string,
-                         '(theme:ENV_CLIMATECHANGE OR theme:LEADER)&startdatetime=20200513000000&'
+                         '(theme:ENV_CLIMATECHANGE OR theme:LEADER) &startdatetime=20200513000000&'
                          'enddatetime=20200514000000&maxrecords=250')
 
     def test_theme_and_keyword(self):
         f = Filters(keyword="airline", theme="ENV_CLIMATECHANGE", start_date="2020-05-13", end_date="2020-05-14")
         self.assertEqual(f.query_string,
-                         '"airline"theme:ENV_CLIMATECHANGE&startdatetime=20200513000000&'
+                         '"airline" theme:ENV_CLIMATECHANGE &startdatetime=20200513000000&'
                          'enddatetime=20200514000000&maxrecords=250')
 
 
@@ -42,10 +42,10 @@ class NearTestCast(unittest.TestCase):
     Test that `near()` generates the right filters and errors.
     """
     def test_two_words(self):
-        self.assertEqual(near(5, "airline", "crisis"), 'near5:"airline crisis"')
+        self.assertEqual(near(5, "airline", "crisis"), 'near5:"airline crisis" ')
 
     def test_three_words(self):
-        self.assertEqual(near(10, "airline", "climate", "change"), 'near10:"airline climate change"')
+        self.assertEqual(near(10, "airline", "climate", "change"), 'near10:"airline climate change" ')
 
     def test_one_word(self):
         with self.assertRaisesRegex(ValueError, "At least two words"):
@@ -57,7 +57,7 @@ class RepeatTestCase(unittest.TestCase):
     Test that `repeat()` generates the correct filters and errors.
     """
     def test_repeat(self):
-        self.assertEqual(repeat(3, "environment"), 'repeat3:"environment"')
+        self.assertEqual(repeat(3, "environment"), 'repeat3:"environment" ')
 
     def test_repeat_phrase(self):
         with self.assertRaisesRegex(ValueError, "single word"):


### PR DESCRIPTION
Fixes #6

Previously only the first filter condition in the query was applied. Due
to the order in which filters are constructed, this was usually `keyword`.

Someone making a search with

```
f = Filters(
    keyword = "paypal",
    timespan = "7d",
    theme = "TAX_ECON_PRICE"
)
```

would get the same results as someone using

```
f = Filters(
    keyword = "paypal",
    timespan = "7d"
)
```

which is incorrect.

This is because the API needs a space between each of the filter conditions
in the query.

Add a space at the end of every filter condition when constructing the
query string. I have tested and the API returns the same results if a
space is at the end of a query with only a single condition, ie.

```
f = Filters(
    keyword = "paypal",
    timespan = "7d"
)
```

and

```
f = Filters(
    keyword = "paypal ",
    timespan = "7d"
)
```
have the same results, so it is safe to always add the space in.

Also add a changelog so it's easy to keep track of what's happening when a new version is released.