### PR TITLE
Fix `multi_repeat` spacing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## Unreleased
+Fix a bug in `multi_repeat` which caused a bad response from the API which could not be parsed
+
 ## 1.3.1
 Fix bug when only the first of the filter conditions (eg. keyword, near, etc.) was used
 

--- a/gdeltdoc/filters.py
+++ b/gdeltdoc/filters.py
@@ -48,7 +48,7 @@ def multi_repeat(repeats: List[Tuple[int, str]], method: str) -> str:
         raise ValueError(f"method must be one of AND or OR, not {method}")
 
     to_repeat = [repeat(n, keyword) for (n, keyword) in repeats]
-    return method.join(to_repeat)
+    return f"{method} ".join(to_repeat)
 
 
 class Filters:

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -1,4 +1,4 @@
-from gdeltdoc import Filters, near, repeat
+from gdeltdoc import Filters, near, repeat, multi_repeat
 
 import unittest
 
@@ -62,3 +62,15 @@ class RepeatTestCase(unittest.TestCase):
     def test_repeat_phrase(self):
         with self.assertRaisesRegex(ValueError, "single word"):
             repeat(5, "climate change   ")
+
+class MultiRepeatTestCase(unittest.TestCase):
+    """
+    Test that `multi_repeat() generates the correct filters and errors.
+    """
+
+    def test_multi_repeat(self):
+        self.assertEqual(multi_repeat([(2, "airline"), (3, "airport")], "AND"), 'repeat2:"airline" AND repeat3:"airport" ')
+
+    def test_multi_repeat_checks_method(self):
+        with self.assertRaisesRegex(ValueError, "method must be one of AND or OR"):
+            multi_repeat([(2, "airline"), (3, "airport")], "NOT_A_METHOD")


### PR DESCRIPTION
By adding a space after `AND` in the query string. This missing space
was stopping the API from parsing the query string. The error response
was a plain text string with a 200 response code, so it was parsed into
bytes, leading to pandas trying to parse a string of numbers into a
dataframe which failed with errors like:

```
TypeError                                 Traceback (most recent call last)
~\AppData\Local\Temp\ipykernel_1576\752362330.py in <module>
      2
      3 # Search for articles matching the filters
----> 4 articles = gd.article_search(f)
      5
      6 # Get a timeline of the number of articles matching the filters

~\.conda\envs\newEnv\lib\site-packages\gdeltdoc\api_client.py in article_search(self, filters)
     77         """
     78         articles = self._query("artlist", filters.query_string)
---> 79         if "articles" in articles:
     80             return pd.DataFrame(articles["articles"])
     81         else:

TypeError: argument of type 'int' is not iterable
```

Closes #11 