### PR TITLE
Fix multi repeat OR filter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## Unreleased
+Fix a bug in `multi_repeat` which meant any filter using `OR` would fail
+
 ## 1.3.2
 Fix a bug in `multi_repeat` which caused a bad response from the API which could not be parsed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## 1.3.3
 Fix a bug in `multi_repeat` which meant any filter using `OR` would fail
 
 ## 1.3.2

--- a/gdeltdoc/__init__.py
+++ b/gdeltdoc/__init__.py
@@ -1,4 +1,4 @@
 from gdeltdoc.api_client import GdeltDoc
 from gdeltdoc.filters import Filters, near, repeat, multi_repeat
 
-__version__ = "1.3.2"
+__version__ = "1.3.3"

--- a/gdeltdoc/filters.py
+++ b/gdeltdoc/filters.py
@@ -48,7 +48,11 @@ def multi_repeat(repeats: List[Tuple[int, str]], method: str) -> str:
         raise ValueError(f"method must be one of AND or OR, not {method}")
 
     to_repeat = [repeat(n, keyword) for (n, keyword) in repeats]
-    return f"{method} ".join(to_repeat)
+
+    if method == "AND":
+        return f"{method} ".join(to_repeat)
+    elif method == "OR":
+        return "(" + f"{method} ".join(to_repeat) + ")"
 
 
 class Filters:

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -71,6 +71,9 @@ class MultiRepeatTestCase(unittest.TestCase):
     def test_multi_repeat(self):
         self.assertEqual(multi_repeat([(2, "airline"), (3, "airport")], "AND"), 'repeat2:"airline" AND repeat3:"airport" ')
 
+    def test_multi_repeat_or(self):
+        self.assertEqual(multi_repeat([(2, "airline"), (3, "airport")], "OR"), '(repeat2:"airline" OR repeat3:"airport" )')
+
     def test_multi_repeat_checks_method(self):
         with self.assertRaisesRegex(ValueError, "method must be one of AND or OR"):
             multi_repeat([(2, "airline"), (3, "airport")], "NOT_A_METHOD")


### PR DESCRIPTION
Any query using this filter failed with the error

`TypeError: argument of type 'int' is not iterable`

This is because filters using OR require brackets around the statements
compared with OR. These brackets must only be used when the filter is
using OR - they'll cause an error if they're present for an AND filter.

Add the brackets in for only the OR filters which allows queries to
complete successfully.

Fixes https://github.com/alex9smith/gdelt-doc-api/issues/15

---
```
Python 3.9.4 (default, May 10 2021, 13:51:57)
Type 'copyright', 'credits' or 'license' for more information
IPython 8.2.0 -- An enhanced Interactive Python. Type '?' for help.

In [1]: from gdeltdoc import Filters, near, repeat, GdeltDoc, multi_repeat
   ...:
   ...: f = Filters(
   ...:     start_date = "2017-05-01",
   ...:     end_date = "2022-02-02",
   ...:     num_records = 250,
   ...:     keyword = "low carbon",
   ...:     near = near(10, 'emission', 'airport'),
   ...:     repeat = multi_repeat([(2, "airline"), (3, "airport")], "OR")
   ...: )
   ...: gd = GdeltDoc()
   ...:
   ...: # Search for articles matching the filters
   ...: articles = gd.article_search(f)

In [2]: articles
Out[2]:
                                                 url                                         url_mobile                                              title  ...                 domain language   sourcecountry
0  https://www.ainonline.com:443/aviation-news/ae...  https://www.ainonline.com/aviation-news/aerosp...           UK Airport Adds Hydrogen Fueling Station  ...          ainonline.com  English   United States
1  https://www.schengenvisainfo.com/news/denmark-...                                                     Denmark Among First EU Countries Determined to...  ...   schengenvisainfo.com  English
2  https://www.newcivilengineer.com/latest/low-em...                                                     Low emission aviation plans are not a green li...  ...   newcivilengineer.com  English  United Kingdom
3  https://www.theengineer.co.uk/decarbonise-avia...                                                                The Engineer Q & A : Green skies ahead  ...      theengineer.co.uk  English  United Kingdom
4  https://centreforaviation.com/analysis/reports...                                                     Aviation Sustainability and the Environment , ...  ...  centreforaviation.com  English           China

[5 rows x 8 columns]
```