### PR TITLE
Validate `timespan` filter parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## Unreleased
+Validate `timespan` filter parameter to make sure it's an allowed value
+
 ## 1.3.3
 Fix a bug in `multi_repeat` which meant any filter using `OR` would fail
 

--- a/gdeltdoc/__init__.py
+++ b/gdeltdoc/__init__.py
@@ -1,4 +1,4 @@
 from gdeltdoc.api_client import GdeltDoc
-from gdeltdoc.filters import Filters, near, repeat, multi_repeat
+from gdeltdoc.filters import Filters, near, repeat, multi_repeat, VALID_TIMESPAN_UNITS
 
 __version__ = "1.3.3"


### PR DESCRIPTION
Previously if this was wrong the query would fail when trying to parse
the (non-JSON) error response from the API. Catch it earlier in the
program and provide some helpful error messages to users.

Prevents errors like in #17 