### PR TITLE
Catch API errors when a query string is invalid 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## 1.4.0
 Validate `timespan` filter parameter to make sure it's an allowed value
 Catch API errors when a query string is invalid and return them to the user
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 Validate `timespan` filter parameter to make sure it's an allowed value
+Catch API errors when a query string is invalid and return them to the user
 
 ## 1.3.3
 Fix a bug in `multi_repeat` which meant any filter using `OR` would fail

--- a/gdeltdoc/__init__.py
+++ b/gdeltdoc/__init__.py
@@ -1,4 +1,4 @@
 from gdeltdoc.api_client import GdeltDoc
 from gdeltdoc.filters import Filters, near, repeat, multi_repeat, VALID_TIMESPAN_UNITS
 
-__version__ = "1.3.3"
+__version__ = "1.4.0"

--- a/gdeltdoc/api_client.py
+++ b/gdeltdoc/api_client.py
@@ -154,4 +154,9 @@ class GdeltDoc:
         if response.status_code not in [200, 202]:
             raise ValueError("The gdelt api returned a non-successful statuscode. This is the response message: {}".
                              format(response.text))
+
+        # Response is text/html if it's an error and application/json if it's ok
+        if "text/html" in response.headers["content-type"]:
+            raise ValueError(f"The query was not valid. The API error message was: {response.text.strip()}")
+
         return load_json(response.content, self.max_depth_json_parsing)

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -100,3 +100,9 @@ class TimelineSearchTestCase(unittest.TestCase):
 
     def test_vol_raw_has_three_columns(self):
         self.assertEqual(self.all_results[1].shape[1], 3)
+
+class QueryTestCase(unittest.TestCase):
+
+    def test_handles_invalid_query_string(self):
+        with self.assertRaisesRegex(ValueError, "The query was not valid. The API error message was"):
+            GdeltDoc()._query("artlist", "environment&timespan=mins15")


### PR DESCRIPTION
When a query produces an invalid query string, the API returns a plain
text error message. These were being converted into bytes and then
tried to parse as JSON which was failing and returned the cryptic error
message `TypeError: argument of type 'int' is not iterable`.

When the API returns valid results it uses an `application/json` content
type, so check the content type of the response and if it's `text/html`
raise an error and display the API error message to the user.

Mostly addresses #18 