### PR TITLE
Update startdate/enddate to also accept hours, minutes, seconds

### DIFF
--- a/gdeltdoc/filters.py
+++ b/gdeltdoc/filters.py
@@ -161,9 +161,9 @@ class Filters:
 
         if start_date:
             self.query_params.append(
-                f'&startdatetime={start_date.replace("-", "")}000000'
+                f'&startdatetime={start_date.replace("-", "")}'
             )
-            self.query_params.append(f'&enddatetime={end_date.replace("-", "")}000000')
+            self.query_params.append(f'&enddatetime={end_date.replace("-", "")}')
         else:
             # Use timespan
             self._validate_timespan(timespan)


### PR DESCRIPTION
The gdelt api accepts hours, minutes, seconds however the python wrapper always assigns them to 0. Given that for articles you are limited to 250 results, this is a good way to enlarge your pool of responses by issuing more queries segmented by non-overlapping time slices (that sum up to your desired interval).

This change would break existing code, so ideally we can add some parameters like hours, minutes, seconds which default to '00', but I leave this decision to the library owner.