### PR TITLE
Fix JSONDecodeErrors when loading bad responses from the API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+Fix JSONDecodeError when loading bad responses from the API (#47)
+
 ## 1.8.0
 
 Add multiple nears (#31)(#45)

--- a/gdeltdoc/helpers.py
+++ b/gdeltdoc/helpers.py
@@ -21,7 +21,7 @@ def load_json(json_message, max_recursion_depth: int = 100, recursion_depth: int
 
         idx_to_replace = int(e.args[0].split(" ")[-1][:-1])
         json_message = (
-            json_message[:idx_to_replace] + " " + json_message[idx_to_replace + 1 :]
+            json_message[:idx_to_replace] + " " + json_message[idx_to_replace + 1 :]  # type: ignore
         )
         return load_json(json_message, max_recursion_depth, recursion_depth + 1)
 

--- a/gdeltdoc/helpers.py
+++ b/gdeltdoc/helpers.py
@@ -3,30 +3,26 @@ import json
 
 def load_json(json_message, max_recursion_depth: int = 100, recursion_depth: int = 0):
     """
-    tries to load a json formatted string and removes offending characters if present
-    https://stackoverflow.com/questions/37805751/simplejson-scanner-jsondecodeerror-invalid-x-escape-sequence-us-line-1-colu
+    tries to load a JSON formatted string and removes offending characters if present.
 
-    :param json_message:
-    :param max_recursion_depth:
-    :param recursion_depth:
-    :return:
+    :param json_message: The JSON string to load.
+    :param max_recursion_depth: The maximum recursion depth allowed.
+    :param recursion_depth: The current recursion depth.
+    :return: The parsed JSON object.
     """
     try:
-        result = json.loads(json_message)
-    except Exception as e:
-        if recursion_depth >= max_recursion_depth:
-            raise ValueError("Max Recursion depth is reached. JSON can´t be parsed!")
-        # Find the offending character index:
-        idx_to_replace = int(e.pos)
-        # Remove the offending character:
         if isinstance(json_message, bytes):
-            json_message.decode("utf-8")
-        json_message = list(json_message)
-        json_message[idx_to_replace] = " "
-        new_message = "".join(str(m) for m in json_message)
-        return load_json(
-            json_message=new_message,
-            max_recursion_depth=max_recursion_depth,
-            recursion_depth=recursion_depth + 1,
+            json_message = json_message.decode()
+        result = json.loads(json_message)
+
+    except ValueError as e:
+        if recursion_depth >= max_recursion_depth:
+            raise ValueError("Max recursion depth is reached.")
+
+        idx_to_replace = int(e.args[0].split(" ")[-1][:-1])
+        json_message = (
+            json_message[:idx_to_replace] + " " + json_message[idx_to_replace + 1 :]
         )
+        return load_json(json_message, max_recursion_depth, recursion_depth + 1)
+
     return result


### PR DESCRIPTION
Simplifies the logic to replace bad sections of the JSON body in the API responses. This should address the JSONDecodeError issues that have been raised. Thanks to @juste97 for the work on this.

This supersedes #29 and closes #28 and #26 