### PR TITLE
Handle 0 results in timeline search

### DIFF
--- a/gdeltdoc/api_client.py
+++ b/gdeltdoc/api_client.py
@@ -106,6 +106,10 @@ class GdeltDoc:
         """
         timeline = self._query(mode, filters.query_string)
 
+        # If no results
+        if len(timeline["timeline"]) == 0:
+            return pd.DataFrame()
+
         results = {
             "datetime": [entry["date"] for entry in timeline["timeline"][0]["data"]]
         }


### PR DESCRIPTION
If the API returns 0 results, just return an empty dataframe. This is consistent with the behaviour of the article search method.

Closes #32