### PR TITLE
Fix error inporting `Unpack` in older Python versions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,11 +11,14 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python: ["3.10", "3.13"]
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
         with:
-          python-version: "3.13"
+          python-version: ${{matrix.python}}
 
       - name: Install dependencies
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+Fix `Unpack` type hint for older Python versions
+
 ## 1.10.1
 
 Add workaround for domain bug to filter docstring (#54)

--- a/gdeltdoc/filters.py
+++ b/gdeltdoc/filters.py
@@ -1,4 +1,11 @@
-from typing import Optional, List, Union, Tuple, Unpack
+from typing import Optional, List, Union, Tuple
+
+try:
+    from typing import Unpack
+except ImportError:
+    from typing_extensions import Unpack
+
+
 from string import ascii_lowercase, digits
 from gdeltdoc.validation import validate_tone
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 pandas>=2.2.3
 requests>=2.32.3
+typing_extensions>=4.13.0


### PR DESCRIPTION
`Unpack` was only moved to the native `typing` in Python version 3.12 so older versions now fail with an `ImportError`.

Install the `typing_extensions` library which backports these changes and try to import fron that if the native import fails.

This closes #59