### PR TITLE
Raise errors when the GDELT API returns a non-200 status code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+Raise custom errors when the GDELT API returns a non-200 status code (#66)
+
 ## 1.11.0
 
 Allow datetimes to be passed to `start_date` and `end_date` (#63)

--- a/gdeltdoc/api_client.py
+++ b/gdeltdoc/api_client.py
@@ -6,7 +6,7 @@ from gdeltdoc.filters import Filters
 from typing import Dict
 
 from gdeltdoc.helpers import load_json
-
+from gdeltdoc.errors import raise_response_error
 from gdeltdoc._version import version
 
 
@@ -164,14 +164,12 @@ class GdeltDoc:
             headers=headers,
         )
 
-        if response.status_code not in [200, 202]:
-            raise ValueError(
-                "The gdelt api returned a non-successful statuscode. This is the response message: {}".format(
-                    response.text
-                )
-            )
+        raise_response_error(response=response)
 
-        # Response is text/html if it's an error and application/json if it's ok
+        # Sometimes the API responds to an invalid request with a 200 status code
+        # and a text/html content type. I can't figure out a pattern for when that happens so
+        # this raises a ValueError with the response content instead of one of the library's
+        # custom error types.
         if "text/html" in response.headers["content-type"]:
             raise ValueError(
                 f"The query was not valid. The API error message was: {response.text.strip()}"

--- a/gdeltdoc/errors.py
+++ b/gdeltdoc/errors.py
@@ -1,0 +1,53 @@
+from enum import Enum, unique
+from requests import Response, HTTPError
+
+
+@unique
+class HttpResponseCodes(Enum):
+    OK = 200
+    BAD_REQUEST = 400
+    NOT_FOUND = 404
+    RATE_LIMIT = 429
+
+
+class BadRequestError(HTTPError):
+    """Raised when the response from the API is a 400 status"""
+
+
+class NotFoundError(HTTPError):
+    """Raised when the response from the API is a 404 status"""
+
+
+class RateLimitError(HTTPError):
+    """Raised when the response from the API is a 429 status"""
+
+
+class ClientRequestError(HTTPError):
+    """Raised when the response from the API is a 4XX status that's not 400, 404 or 429"""
+
+
+class ServerError(HTTPError):
+    """Raised when the response from the API is a 5XX status"""
+
+
+def raise_response_error(response: Response) -> None:
+    if response.status_code == HttpResponseCodes.OK.value:
+        return
+
+    elif response.status_code == HttpResponseCodes.BAD_REQUEST.value:
+        raise BadRequestError(response=response)
+
+    elif response.status_code == HttpResponseCodes.NOT_FOUND.value:
+        raise NotFoundError(response=response)
+
+    elif response.status_code == HttpResponseCodes.RATE_LIMIT.value:
+        raise RateLimitError(response=response)
+
+    elif response.status_code >= 400 and response.status_code < 500:
+        raise ClientRequestError(response=response)
+
+    elif response.status_code >= 500 and response.status_code < 600:
+        raise ServerError(response=response)
+
+    else:
+        raise HTTPError(response=response)

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,9 +1,11 @@
 import unittest.mock
 import pandas as pd
 import unittest
+from datetime import datetime, timedelta
 
 from gdeltdoc import GdeltDoc, Filters
-from datetime import datetime, timedelta
+from gdeltdoc.errors import RateLimitError
+from tests.test_errors import build_response
 
 
 class ArticleSearchTestCast(unittest.TestCase):
@@ -120,3 +122,9 @@ class QueryTestCase(unittest.TestCase):
             ValueError, "The query was not valid. The API error message was"
         ):
             GdeltDoc()._query("artlist", "environment&timespan=mins15")
+
+    def test_raises_an_error_when_response_is_bad_status_code(self):
+        with self.assertRaises(RateLimitError):
+            with unittest.mock.patch("requests.get") as requests_mock:
+                requests_mock.return_value = build_response(429)
+                GdeltDoc()._query("artlist", "")

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -1,0 +1,48 @@
+import unittest
+
+from requests import Response, HTTPError
+from gdeltdoc.errors import (
+    HttpResponseCodes,
+    raise_response_error,
+    BadRequestError,
+    NotFoundError,
+    RateLimitError,
+    ClientRequestError,
+    ServerError,
+)
+
+
+def build_response(status_code: int) -> Response:
+    response = Response()
+    response._content = str.encode("text")
+    response.status_code = status_code
+    return response
+
+
+class RaiseResponseErrorTestCase(unittest.TestCase):
+    def test_doesnt_raise_when_status_200(self):
+        raise_response_error(build_response(HttpResponseCodes.OK.value))
+
+    def test_raises_bad_request_error_when_status_400(self):
+        with self.assertRaises(BadRequestError):
+            raise_response_error(build_response(HttpResponseCodes.BAD_REQUEST.value))
+
+    def test_raises_not_found_error_when_status_404(self):
+        with self.assertRaises(NotFoundError):
+            raise_response_error(build_response(HttpResponseCodes.NOT_FOUND.value))
+
+    def test_raises_rate_limit_error_when_status_429(self):
+        with self.assertRaises(RateLimitError):
+            raise_response_error(build_response(HttpResponseCodes.RATE_LIMIT.value))
+
+    def test_raises_server_error_when_status_5XX(self):
+        with self.assertRaises(ServerError):
+            raise_response_error(build_response(503))
+
+    def test_raises_client_error_when_status_4XX(self):
+        with self.assertRaises(ClientRequestError):
+            raise_response_error(build_response(403))
+
+    def test_raises_http_error_when_status_unhandled(self):
+        with self.assertRaises(HTTPError):
+            raise_response_error(build_response(600))


### PR DESCRIPTION
Raise a more specific error when the GDELT API returns a non-200 status code. 

This adds several new custom error classes based on the most frequent non-200 response status codes. All of these are subclasses of the `requests.HTTPError` which means consumers can either choose to catch that type of error and handle all response errors, or catch each individual type. 

This allows users of this library to define their own error handling and retry logic. For example, now you could choose to wait and retry a `RateLimitError` but not catch a `BadRequestError` to highlight a non-working query.

Closes #64 